### PR TITLE
Pretty Select Focus

### DIFF
--- a/pretty-select/index.html
+++ b/pretty-select/index.html
@@ -6,12 +6,12 @@
 </head>
 <body>
   <div class="select">
-    <span class="arr"></span>
     <select>
       <option>All about that bass</option>
       <option>Dear Future Husband</option>
       <option>Close Your Eyes</option>
     </select>
+    <span class="arr"></span>
   </div>
 </body>
 </html>

--- a/pretty-select/styles.css
+++ b/pretty-select/styles.css
@@ -64,3 +64,10 @@ body {
   line-height: inherit;
 }
 
+.select select:focus {
+  border-color:#1A70FF;
+}
+
+.select select:focus + .arr:before {
+  border-top-color:#1A70FF;
+}


### PR DESCRIPTION
had to move the order of the elements in the HTML so the adjacent
selector could be used

Closes lugolabs/tutorials#5

![](http://j4p.us/3Z2b1r082W1K/Screen%20Shot%202016-06-09%20at%203.28.44%20PM.png)
